### PR TITLE
Moving back to RocksDB

### DIFF
--- a/meilidb-data/Cargo.toml
+++ b/meilidb-data/Cargo.toml
@@ -16,7 +16,7 @@ ordered-float = { version = "1.0.2", features = ["serde"] }
 sdset = "0.3.2"
 serde = { version = "1.0.91", features = ["derive"] }
 serde_json = { version = "1.0.39", features = ["preserve_order"] }
-sled = "0.23.0"
+rocksdb = "0.12.2"
 toml = { version = "0.5.0", features = ["preserve_order"] }
 zerocopy = "0.2.2"
 
@@ -27,10 +27,6 @@ rev = "40b3d48"
 [dependencies.fst]
 git = "https://github.com/Kerollmops/fst.git"
 branch = "arc-byte-slice"
-
-[features]
-default = []
-compression = ["sled/compression"]
 
 [dev-dependencies]
 tempfile = "3.0.7"

--- a/meilidb-data/Cargo.toml
+++ b/meilidb-data/Cargo.toml
@@ -16,7 +16,7 @@ ordered-float = { version = "1.0.2", features = ["serde"] }
 sdset = "0.3.2"
 serde = { version = "1.0.91", features = ["derive"] }
 serde_json = { version = "1.0.39", features = ["preserve_order"] }
-rocksdb = "0.12.2"
+rocksdb = { version = "0.12.2", default-features = false }
 toml = { version = "0.5.0", features = ["preserve_order"] }
 zerocopy = "0.2.2"
 

--- a/meilidb-data/src/database/custom_settings.rs
+++ b/meilidb-data/src/database/custom_settings.rs
@@ -1,13 +1,22 @@
 use std::sync::Arc;
-use std::ops::Deref;
+use rocksdb::DBVector;
 
 #[derive(Clone)]
 pub struct CustomSettings(pub Arc<rocksdb::DB>, pub String);
 
-impl Deref for CustomSettings {
-    type Target = rocksdb::DB;
+impl CustomSettings {
+    pub fn set<K, V>(&self, key: K, value: V) -> Result<(), rocksdb::Error>
+    where K: AsRef<[u8]>,
+          V: AsRef<[u8]>,
+    {
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        self.0.put_cf(cf, key, value)
+    }
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    pub fn get<K, V>(&self, key: K) -> Result<Option<DBVector>, rocksdb::Error>
+    where K: AsRef<[u8]>,
+    {
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        self.0.get_cf(cf, key)
     }
 }

--- a/meilidb-data/src/database/custom_settings.rs
+++ b/meilidb-data/src/database/custom_settings.rs
@@ -1,22 +1,20 @@
-use std::sync::Arc;
 use rocksdb::DBVector;
+use crate::database::raw_index::InnerRawIndex;
 
 #[derive(Clone)]
-pub struct CustomSettings(pub Arc<rocksdb::DB>, pub String);
+pub struct CustomSettings(pub(crate) InnerRawIndex);
 
 impl CustomSettings {
     pub fn set<K, V>(&self, key: K, value: V) -> Result<(), rocksdb::Error>
     where K: AsRef<[u8]>,
           V: AsRef<[u8]>,
     {
-        let cf = self.0.cf_handle(&self.1).unwrap();
-        self.0.put_cf(cf, key, value)
+        self.0.set(key, value)
     }
 
     pub fn get<K, V>(&self, key: K) -> Result<Option<DBVector>, rocksdb::Error>
     where K: AsRef<[u8]>,
     {
-        let cf = self.0.cf_handle(&self.1).unwrap();
-        self.0.get_cf(cf, key)
+        self.0.get(key)
     }
 }

--- a/meilidb-data/src/database/custom_settings.rs
+++ b/meilidb-data/src/database/custom_settings.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 use std::ops::Deref;
 
 #[derive(Clone)]
-pub struct CustomSettings(pub Arc<sled::Tree>);
+pub struct CustomSettings(pub Arc<rocksdb::DB>, pub String);
 
 impl Deref for CustomSettings {
-    type Target = sled::Tree;
+    type Target = rocksdb::DB;
 
-    fn deref(&self) -> &sled::Tree {
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }

--- a/meilidb-data/src/database/custom_settings.rs
+++ b/meilidb-data/src/database/custom_settings.rs
@@ -1,20 +1,13 @@
-use rocksdb::DBVector;
+use std::ops::Deref;
 use crate::database::raw_index::InnerRawIndex;
 
 #[derive(Clone)]
 pub struct CustomSettings(pub(crate) InnerRawIndex);
 
-impl CustomSettings {
-    pub fn set<K, V>(&self, key: K, value: V) -> Result<(), rocksdb::Error>
-    where K: AsRef<[u8]>,
-          V: AsRef<[u8]>,
-    {
-        self.0.set(key, value)
-    }
+impl Deref for CustomSettings {
+    type Target = InnerRawIndex;
 
-    pub fn get<K, V>(&self, key: K) -> Result<Option<DBVector>, rocksdb::Error>
-    where K: AsRef<[u8]>,
-    {
-        self.0.get(key)
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/meilidb-data/src/database/docs_words_index.rs
+++ b/meilidb-data/src/database/docs_words_index.rs
@@ -3,15 +3,16 @@ use meilidb_core::DocumentId;
 use super::Error;
 
 #[derive(Clone)]
-pub struct DocsWordsIndex(pub Arc<sled::Tree>);
+pub struct DocsWordsIndex(pub Arc<rocksdb::DB>, pub String);
 
 impl DocsWordsIndex {
     pub fn doc_words(&self, id: DocumentId) -> Result<Option<fst::Set>, Error> {
         let key = id.0.to_be_bytes();
-        match self.0.get(key)? {
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        match self.0.get_pinned_cf(cf, key)? {
             Some(bytes) => {
                 let len = bytes.len();
-                let value = bytes.into();
+                let value = Arc::from(bytes.as_ref());
                 let fst = fst::raw::Fst::from_shared_bytes(value, 0, len)?;
                 Ok(Some(fst::Set::from(fst)))
             },
@@ -21,13 +22,15 @@ impl DocsWordsIndex {
 
     pub fn set_doc_words(&self, id: DocumentId, words: &fst::Set) -> Result<(), Error> {
         let key = id.0.to_be_bytes();
-        self.0.set(key, words.as_fst().as_bytes())?;
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        self.0.put_cf(cf, key, words.as_fst().as_bytes())?;
         Ok(())
     }
 
     pub fn del_doc_words(&self, id: DocumentId) -> Result<(), Error> {
         let key = id.0.to_be_bytes();
-        self.0.del(key)?;
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        self.0.delete_cf(cf, key)?;
         Ok(())
     }
 }

--- a/meilidb-data/src/database/documents_addition.rs
+++ b/meilidb-data/src/database/documents_addition.rs
@@ -122,6 +122,7 @@ impl<'a> DocumentsAddition<'a> {
         let ranked_map = self.ranked_map;
         let schema = lease_inner.schema.clone();
         let raw = lease_inner.raw.clone();
+        lease_inner.raw.compact();
 
         let inner = InnerIndex { words, schema, ranked_map, raw };
         self.inner.0.store(Arc::new(inner));

--- a/meilidb-data/src/database/documents_deletion.rs
+++ b/meilidb-data/src/database/documents_deletion.rs
@@ -121,6 +121,7 @@ impl<'a> DocumentsDeletion<'a> {
         let ranked_map = lease_inner.ranked_map.clone();
         let schema = lease_inner.schema.clone();
         let raw = lease_inner.raw.clone();
+        lease_inner.raw.compact();
 
         let inner = InnerIndex { words, schema, ranked_map, raw };
         self.inner.0.store(Arc::new(inner));

--- a/meilidb-data/src/database/documents_index.rs
+++ b/meilidb-data/src/database/documents_index.rs
@@ -44,6 +44,26 @@ impl DocumentsIndex {
 
         DocumentFieldsIter(iter, end.to_vec())
     }
+
+    pub fn len(&self) -> Result<usize, rocksdb::Error> {
+        let mut last_document_id = None;
+        let mut count = 0;
+
+        let from = rocksdb::IteratorMode::Start;
+        let iterator = self.0.iterator(from)?;
+
+        for (key, value) in iterator {
+            let slice = key.as_ref().try_into().unwrap();
+            let document_id = DocumentAttrKey::from_be_bytes(slice).document_id;
+
+            if Some(document_id) != last_document_id {
+                last_document_id = Some(document_id);
+                count += 1;
+            }
+        }
+
+        Ok(count)
+    }
 }
 
 pub struct DocumentFieldsIter<'a>(rocksdb::DBIterator<'a>, Vec<u8>);

--- a/meilidb-data/src/database/documents_index.rs
+++ b/meilidb-data/src/database/documents_index.rs
@@ -2,69 +2,77 @@ use std::sync::Arc;
 use std::convert::TryInto;
 
 use meilidb_core::DocumentId;
-use sled::IVec;
+use rocksdb::DBVector;
 
 use crate::document_attr_key::DocumentAttrKey;
 use crate::schema::SchemaAttr;
 
 #[derive(Clone)]
-pub struct DocumentsIndex(pub Arc<sled::Tree>);
+pub struct DocumentsIndex(pub Arc<rocksdb::DB>, pub String);
 
 impl DocumentsIndex {
-    pub fn document_field(&self, id: DocumentId, attr: SchemaAttr) -> sled::Result<Option<IVec>> {
+    pub fn document_field(&self, id: DocumentId, attr: SchemaAttr) -> Result<Option<DBVector>, rocksdb::Error> {
         let key = DocumentAttrKey::new(id, attr).to_be_bytes();
-        self.0.get(key)
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        self.0.get_cf(cf, key)
     }
 
-    pub fn set_document_field(&self, id: DocumentId, attr: SchemaAttr, value: Vec<u8>) -> sled::Result<()> {
+    pub fn set_document_field(&self, id: DocumentId, attr: SchemaAttr, value: Vec<u8>) -> Result<(), rocksdb::Error> {
         let key = DocumentAttrKey::new(id, attr).to_be_bytes();
-        self.0.set(key, value)?;
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        self.0.put_cf(cf, key, value)?;
         Ok(())
     }
 
-    pub fn del_document_field(&self, id: DocumentId, attr: SchemaAttr) -> sled::Result<()> {
+    pub fn del_document_field(&self, id: DocumentId, attr: SchemaAttr) -> Result<(), rocksdb::Error> {
         let key = DocumentAttrKey::new(id, attr).to_be_bytes();
-        self.0.del(key)?;
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        self.0.delete_cf(cf, key)?;
         Ok(())
     }
 
-    pub fn del_all_document_fields(&self, id: DocumentId) -> sled::Result<()> {
+    pub fn del_all_document_fields(&self, id: DocumentId) -> Result<(), rocksdb::Error> {
         let start = DocumentAttrKey::new(id, SchemaAttr::min()).to_be_bytes();
         let end = DocumentAttrKey::new(id, SchemaAttr::max()).to_be_bytes();
-        let document_attrs = self.0.range(start..=end).keys();
 
-        for key in document_attrs {
-            self.0.del(key?)?;
-        }
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.delete_range_cf(cf, start, end)?;
+        self.0.write(batch)?;
 
         Ok(())
     }
 
     pub fn document_fields(&self, id: DocumentId) -> DocumentFieldsIter {
-        let start = DocumentAttrKey::new(id, SchemaAttr::min());
-        let start = start.to_be_bytes();
+        let start = DocumentAttrKey::new(id, SchemaAttr::min()).to_be_bytes();
+        let end = DocumentAttrKey::new(id, SchemaAttr::max()).to_be_bytes();
 
-        let end = DocumentAttrKey::new(id, SchemaAttr::max());
-        let end = end.to_be_bytes();
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        let from = rocksdb::IteratorMode::From(&start[..], rocksdb::Direction::Forward);
+        let iter = self.0.iterator_cf(cf, from).unwrap();
 
-        DocumentFieldsIter(self.0.range(start..=end))
+        DocumentFieldsIter(iter, end.to_vec())
     }
 }
 
-pub struct DocumentFieldsIter<'a>(sled::Iter<'a>);
+pub struct DocumentFieldsIter<'a>(rocksdb::DBIterator<'a>, Vec<u8>);
 
 impl<'a> Iterator for DocumentFieldsIter<'a> {
-    type Item = sled::Result<(SchemaAttr, IVec)>;
+    type Item = Result<(SchemaAttr, Box<[u8]>), rocksdb::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.0.next() {
-            Some(Ok((key, value))) => {
+            Some((key, value)) => {
+
+                if key.as_ref() > self.1.as_ref() {
+                    return None;
+                }
+
                 let slice: &[u8] = key.as_ref();
                 let array = slice.try_into().unwrap();
                 let key = DocumentAttrKey::from_be_bytes(array);
                 Some(Ok((key.attribute, value)))
             },
-            Some(Err(e)) => Some(Err(e)),
             None => None,
         }
     }

--- a/meilidb-data/src/database/error.rs
+++ b/meilidb-data/src/database/error.rs
@@ -7,15 +7,15 @@ pub enum Error {
     SchemaMissing,
     WordIndexMissing,
     MissingDocumentId,
-    SledError(sled::Error),
+    RocksdbError(rocksdb::Error),
     FstError(fst::Error),
     BincodeError(bincode::Error),
     SerializerError(SerializerError),
 }
 
-impl From<sled::Error> for Error {
-    fn from(error: sled::Error) -> Error {
-        Error::SledError(error)
+impl From<rocksdb::Error> for Error {
+    fn from(error: rocksdb::Error) -> Error {
+        Error::RocksdbError(error)
     }
 }
 
@@ -45,7 +45,7 @@ impl fmt::Display for Error {
             SchemaMissing => write!(f, "this index does not have a schema"),
             WordIndexMissing => write!(f, "this index does not have a word index"),
             MissingDocumentId => write!(f, "document id is missing"),
-            SledError(e) => write!(f, "sled error; {}", e),
+            RocksdbError(e) => write!(f, "RocksDB error; {}", e),
             FstError(e) => write!(f, "fst error; {}", e),
             BincodeError(e) => write!(f, "bincode error; {}", e),
             SerializerError(e) => write!(f, "serializer error; {}", e),

--- a/meilidb-data/src/database/main_index.rs
+++ b/meilidb-data/src/database/main_index.rs
@@ -6,11 +6,12 @@ use crate::schema::Schema;
 use super::Error;
 
 #[derive(Clone)]
-pub struct MainIndex(pub Arc<sled::Tree>);
+pub struct MainIndex(pub Arc<rocksdb::DB>, pub String);
 
 impl MainIndex {
     pub fn schema(&self) -> Result<Option<Schema>, Error> {
-        match self.0.get("schema")? {
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        match self.0.get_cf(cf, "schema")? {
             Some(bytes) => {
                 let schema = Schema::read_from_bin(bytes.as_ref())?;
                 Ok(Some(schema))
@@ -22,15 +23,17 @@ impl MainIndex {
     pub fn set_schema(&self, schema: &Schema) -> Result<(), Error> {
         let mut bytes = Vec::new();
         schema.write_to_bin(&mut bytes)?;
-        self.0.set("schema", bytes)?;
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        self.0.put_cf(cf, "schema", bytes)?;
         Ok(())
     }
 
     pub fn words_set(&self) -> Result<Option<fst::Set>, Error> {
-        match self.0.get("words")? {
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        match self.0.get_pinned_cf(cf, "words")? {
             Some(bytes) => {
                 let len = bytes.len();
-                let value = bytes.into();
+                let value = Arc::from(bytes.as_ref());
                 let fst = fst::raw::Fst::from_shared_bytes(value, 0, len)?;
                 Ok(Some(fst::Set::from(fst)))
             },
@@ -39,12 +42,14 @@ impl MainIndex {
     }
 
     pub fn set_words_set(&self, value: &fst::Set) -> Result<(), Error> {
-        self.0.set("words", value.as_fst().as_bytes())?;
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        self.0.put_cf(cf, "words", value.as_fst().as_bytes())?;
         Ok(())
     }
 
     pub fn ranked_map(&self) -> Result<Option<RankedMap>, Error> {
-        match self.0.get("ranked-map")? {
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        match self.0.get_cf(cf, "ranked-map")? {
             Some(bytes) => {
                 let ranked_map = RankedMap::read_from_bin(bytes.as_ref())?;
                 Ok(Some(ranked_map))
@@ -56,7 +61,8 @@ impl MainIndex {
     pub fn set_ranked_map(&self, value: &RankedMap) -> Result<(), Error> {
         let mut bytes = Vec::new();
         value.write_to_bin(&mut bytes)?;
-        self.0.set("ranked_map", bytes)?;
+        let cf = self.0.cf_handle(&self.1).unwrap();
+        self.0.put_cf(cf, "ranked_map", bytes)?;
         Ok(())
     }
 }

--- a/meilidb-data/src/database/main_index.rs
+++ b/meilidb-data/src/database/main_index.rs
@@ -1,17 +1,17 @@
 use std::sync::Arc;
 
+use crate::database::raw_index::InnerRawIndex;
 use crate::ranked_map::RankedMap;
 use crate::schema::Schema;
 
 use super::Error;
 
 #[derive(Clone)]
-pub struct MainIndex(pub Arc<rocksdb::DB>, pub String);
+pub struct MainIndex(pub(crate) InnerRawIndex);
 
 impl MainIndex {
     pub fn schema(&self) -> Result<Option<Schema>, Error> {
-        let cf = self.0.cf_handle(&self.1).unwrap();
-        match self.0.get_cf(cf, "schema")? {
+        match self.0.get_pinned("schema")? {
             Some(bytes) => {
                 let schema = Schema::read_from_bin(bytes.as_ref())?;
                 Ok(Some(schema))
@@ -23,14 +23,12 @@ impl MainIndex {
     pub fn set_schema(&self, schema: &Schema) -> Result<(), Error> {
         let mut bytes = Vec::new();
         schema.write_to_bin(&mut bytes)?;
-        let cf = self.0.cf_handle(&self.1).unwrap();
-        self.0.put_cf(cf, "schema", bytes)?;
+        self.0.set("schema", bytes)?;
         Ok(())
     }
 
     pub fn words_set(&self) -> Result<Option<fst::Set>, Error> {
-        let cf = self.0.cf_handle(&self.1).unwrap();
-        match self.0.get_pinned_cf(cf, "words")? {
+        match self.0.get_pinned("words")? {
             Some(bytes) => {
                 let len = bytes.len();
                 let value = Arc::from(bytes.as_ref());
@@ -42,14 +40,11 @@ impl MainIndex {
     }
 
     pub fn set_words_set(&self, value: &fst::Set) -> Result<(), Error> {
-        let cf = self.0.cf_handle(&self.1).unwrap();
-        self.0.put_cf(cf, "words", value.as_fst().as_bytes())?;
-        Ok(())
+        self.0.set("words", value.as_fst().as_bytes()).map_err(Into::into)
     }
 
     pub fn ranked_map(&self) -> Result<Option<RankedMap>, Error> {
-        let cf = self.0.cf_handle(&self.1).unwrap();
-        match self.0.get_cf(cf, "ranked-map")? {
+        match self.0.get_pinned("ranked-map")? {
             Some(bytes) => {
                 let ranked_map = RankedMap::read_from_bin(bytes.as_ref())?;
                 Ok(Some(ranked_map))
@@ -61,8 +56,7 @@ impl MainIndex {
     pub fn set_ranked_map(&self, value: &RankedMap) -> Result<(), Error> {
         let mut bytes = Vec::new();
         value.write_to_bin(&mut bytes)?;
-        let cf = self.0.cf_handle(&self.1).unwrap();
-        self.0.put_cf(cf, "ranked_map", bytes)?;
+        self.0.set("ranked_map", bytes)?;
         Ok(())
     }
 }

--- a/meilidb-data/src/database/mod.rs
+++ b/meilidb-data/src/database/mod.rs
@@ -26,7 +26,7 @@ use self::documents_deletion::DocumentsDeletion;
 use self::documents_index::DocumentsIndex;
 use self::index::InnerIndex;
 use self::main_index::MainIndex;
-use self::raw_index::RawIndex;
+use self::raw_index::{RawIndex, InnerRawIndex};
 use self::words_index::WordsIndex;
 
 pub struct Database {
@@ -88,31 +88,31 @@ impl Database {
 
                 let main = {
                     self.inner.cf_handle(name).expect("cf not found");
-                    MainIndex(self.inner.clone(), name.to_owned())
+                    MainIndex(InnerRawIndex::new(self.inner.clone(), Arc::from(name)))
                 };
 
                 let words = {
                     let cf_name = format!("{}-words", name);
                     self.inner.cf_handle(&cf_name).expect("cf not found");
-                    WordsIndex(self.inner.clone(), cf_name)
+                    WordsIndex(InnerRawIndex::new(self.inner.clone(), Arc::from(cf_name)))
                 };
 
                 let docs_words = {
                     let cf_name = format!("{}-docs-words", name);
                     self.inner.cf_handle(&cf_name).expect("cf not found");
-                    DocsWordsIndex(self.inner.clone(), cf_name)
+                    DocsWordsIndex(InnerRawIndex::new(self.inner.clone(), Arc::from(cf_name)))
                 };
 
                 let documents = {
                     let cf_name = format!("{}-documents", name);
                     self.inner.cf_handle(&cf_name).expect("cf not found");
-                    DocumentsIndex(self.inner.clone(), cf_name)
+                    DocumentsIndex(InnerRawIndex::new(self.inner.clone(), Arc::from(cf_name)))
                 };
 
                 let custom = {
                     let cf_name = format!("{}-custom", name);
                     self.inner.cf_handle(&cf_name).expect("cf not found");
-                    CustomSettings(self.inner.clone(), cf_name)
+                    CustomSettings(InnerRawIndex::new(self.inner.clone(), Arc::from(cf_name)))
                 };
 
                 let raw_index = RawIndex { main, words, docs_words, documents, custom };
@@ -135,7 +135,7 @@ impl Database {
             Entry::Vacant(vacant) => {
                 let main = {
                     self.inner.create_cf(name, &rocksdb::Options::default())?;
-                    MainIndex(self.inner.clone(), name.to_owned())
+                    MainIndex(InnerRawIndex::new(self.inner.clone(), Arc::from(name)))
                 };
 
                 if let Some(prev_schema) = main.schema()? {
@@ -149,25 +149,25 @@ impl Database {
                 let words = {
                     let cf_name = format!("{}-words", name);
                     self.inner.create_cf(&cf_name, &rocksdb::Options::default())?;
-                    WordsIndex(self.inner.clone(), cf_name)
+                    WordsIndex(InnerRawIndex::new(self.inner.clone(), Arc::from(cf_name)))
                 };
 
                 let docs_words = {
                     let cf_name = format!("{}-docs-words", name);
                     self.inner.create_cf(&cf_name, &rocksdb::Options::default())?;
-                    DocsWordsIndex(self.inner.clone(), cf_name)
+                    DocsWordsIndex(InnerRawIndex::new(self.inner.clone(), Arc::from(cf_name)))
                 };
 
                 let documents = {
                     let cf_name = format!("{}-documents", name);
                     self.inner.create_cf(&cf_name, &rocksdb::Options::default())?;
-                    DocumentsIndex(self.inner.clone(), cf_name)
+                    DocumentsIndex(InnerRawIndex::new(self.inner.clone(), Arc::from(cf_name)))
                 };
 
                 let custom = {
                     let cf_name = format!("{}-custom", name);
                     self.inner.create_cf(&cf_name, &rocksdb::Options::default())?;
-                    CustomSettings(self.inner.clone(), cf_name)
+                    CustomSettings(InnerRawIndex::new(self.inner.clone(), Arc::from(cf_name)))
                 };
 
                 let mut indexes = self.indexes()?.unwrap_or_else(HashSet::new);

--- a/meilidb-data/src/database/raw_index.rs
+++ b/meilidb-data/src/database/raw_index.rs
@@ -10,6 +10,16 @@ pub struct RawIndex {
     pub custom: CustomSettings,
 }
 
+impl RawIndex {
+    pub(crate) fn compact(&self) {
+        self.main.0.compact_range(None::<&[u8]>, None::<&[u8]>);
+        self.words.0.compact_range(None::<&[u8]>, None::<&[u8]>);
+        self.docs_words.0.compact_range(None::<&[u8]>, None::<&[u8]>);
+        self.documents.0.compact_range(None::<&[u8]>, None::<&[u8]>);
+        self.custom.0.compact_range(None::<&[u8]>, None::<&[u8]>);
+    }
+}
+
 #[derive(Clone)]
 pub struct InnerRawIndex {
     database: Arc<rocksdb::DB>,
@@ -64,5 +74,13 @@ impl InnerRawIndex {
         batch.delete_range_cf(cf, start, end)?;
 
         self.database.write(batch)
+    }
+
+    pub fn compact_range<S, E>(&self, start: Option<S>, end: Option<E>)
+    where S: AsRef<[u8]>,
+          E: AsRef<[u8]>,
+    {
+        let cf = self.database.cf_handle(&self.name).expect("cf not found");
+        self.database.compact_range_cf(cf, start, end)
     }
 }

--- a/meilidb-data/src/database/words_index.rs
+++ b/meilidb-data/src/database/words_index.rs
@@ -12,9 +12,24 @@ impl WordsIndex {
         // we must force an allocation to make the memory aligned
         match self.0.get(word)? {
             Some(bytes) => {
-                let layout = LayoutVerified::new_slice(bytes.as_ref()).expect("invalid layout");
-                let slice = layout.into_slice();
-                let setbuf = SetBuf::new_unchecked(slice.to_vec());
+                let vec = match LayoutVerified::new_slice(bytes.as_ref()) {
+                    Some(layout) => layout.into_slice().to_vec(),
+                    None => {
+                        let len = bytes.as_ref().len();
+                        let count = len / std::mem::size_of::<DocIndex>();
+                        let mut buf: Vec<DocIndex> = Vec::with_capacity(count);
+                        unsafe {
+                            let src = bytes.as_ref().as_ptr();
+                            let dst = buf.as_mut_ptr() as *mut u8;
+                            std::ptr::copy_nonoverlapping(src, dst, len);
+                            buf.set_len(count);
+                        }
+                        buf
+                    }
+                };
+
+                let setbuf = SetBuf::new_unchecked(vec);
+
                 Ok(Some(setbuf))
             },
             None => Ok(None),

--- a/meilidb-data/src/lib.rs
+++ b/meilidb-data/src/lib.rs
@@ -6,7 +6,7 @@ mod ranked_map;
 mod serde;
 pub mod schema;
 
-pub use sled;
+pub use rocksdb;
 pub use self::database::{Database, Index, CustomSettings};
 pub use self::number::Number;
 pub use self::ranked_map::RankedMap;

--- a/meilidb-data/src/ranked_map.rs
+++ b/meilidb-data/src/ranked_map.rs
@@ -9,6 +9,10 @@ use crate::{SchemaAttr, Number};
 pub struct RankedMap(HashMap<(DocumentId, SchemaAttr), Number>);
 
 impl RankedMap {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
     pub fn insert(&mut self, document: DocumentId, attribute: SchemaAttr, number: Number) {
         self.0.insert((document, attribute), number);
     }

--- a/meilidb-data/src/serde/mod.rs
+++ b/meilidb-data/src/serde/mod.rs
@@ -36,7 +36,7 @@ use crate::schema::SchemaAttr;
 pub enum SerializerError {
     DocumentIdNotFound,
     RmpError(RmpError),
-    SledError(sled::Error),
+    RocksdbError(rocksdb::Error),
     ParseNumberError(ParseNumberError),
     UnserializableType { type_name: &'static str },
     UnindexableType { type_name: &'static str },
@@ -57,7 +57,7 @@ impl fmt::Display for SerializerError {
                 write!(f, "serialized document does not have an id according to the schema")
             }
             SerializerError::RmpError(e) => write!(f, "rmp serde related error: {}", e),
-            SerializerError::SledError(e) => write!(f, "sled related error: {}", e),
+            SerializerError::RocksdbError(e) => write!(f, "RocksDB related error: {}", e),
             SerializerError::ParseNumberError(e) => {
                 write!(f, "error while trying to parse a number: {}", e)
             },
@@ -89,9 +89,9 @@ impl From<RmpError> for SerializerError {
     }
 }
 
-impl From<sled::Error> for SerializerError {
-    fn from(error: sled::Error) -> SerializerError {
-        SerializerError::SledError(error)
+impl From<rocksdb::Error> for SerializerError {
+    fn from(error: rocksdb::Error) -> SerializerError {
+        SerializerError::RocksdbError(error)
     }
 }
 

--- a/meilidb/examples/create-database.rs
+++ b/meilidb/examples/create-database.rs
@@ -59,7 +59,7 @@ fn index(
 
     let mut system = sysinfo::System::new();
 
-    let index = database.create_index("default", schema.clone())?;
+    let index = database.create_index("test", schema.clone())?;
 
     let mut rdr = csv::Reader::from_path(csv_data_path)?;
     let mut raw_record = csv::StringRecord::new();

--- a/meilidb/examples/query-database.rs
+++ b/meilidb/examples/query-database.rs
@@ -143,7 +143,7 @@ fn main() -> Result<(), Box<Error>> {
     let mut buffer = String::new();
     let input = io::stdin();
 
-    let index = database.open_index("default")?.unwrap();
+    let index = database.open_index("test")?.unwrap();
     let schema = index.schema();
 
     println!("database prepared for you in {:.2?}", start.elapsed());


### PR DESCRIPTION
We faced some disk usage issues with sled and can not work with that so we decided to switch to RocksDB temporarily. It has better disk and memory usage but we faced some read stalls sometimes that we didn't get with sled. We plan to switch back to sled when the disk issues are fixed (it seems to be related to the GC).