### PR TITLE
Support all types of synonyms

### DIFF
--- a/meilidb-core/Cargo.toml
+++ b/meilidb-core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.3.1"
+deunicode = "1.0.0"
 hashbrown = "0.2.2"
 lazy_static = "1.2.0"
 log = "0.4.6"

--- a/meilidb-core/Cargo.toml
+++ b/meilidb-core/Cargo.toml
@@ -25,6 +25,9 @@ git = "https://github.com/Kerollmops/levenshtein-automata.git"
 branch = "arc-byte-slice"
 features = ["fst_automaton"]
 
+[dev-dependencies]
+assert_matches = "1.3"
+
 [features]
 i128 = ["byteorder/i128"]
 nightly = ["hashbrown/nightly", "slice-group-by/nightly"]

--- a/meilidb-core/src/criterion/mod.rs
+++ b/meilidb-core/src/criterion/mod.rs
@@ -113,7 +113,7 @@ impl<'a> Default for Criteria<'a> {
     }
 }
 
-impl<'a> AsRef<[Box<Criterion + 'a>]> for Criteria<'a> {
+impl<'a> AsRef<[Box<dyn Criterion + 'a>]> for Criteria<'a> {
     fn as_ref(&self) -> &[Box<dyn Criterion + 'a>] {
         &self.inner
     }

--- a/meilidb-core/src/lib.rs
+++ b/meilidb-core/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+#[macro_use] extern crate assert_matches;
+
 mod automaton;
 mod distinct_map;
 mod query_builder;

--- a/meilidb-core/src/lib.rs
+++ b/meilidb-core/src/lib.rs
@@ -15,7 +15,7 @@ use serde::{Serialize, Deserialize};
 use slice_group_by::GroupBy;
 use zerocopy::{AsBytes, FromBytes};
 
-pub use self::query_builder::{QueryBuilder, DistinctQueryBuilder};
+pub use self::query_builder::{QueryBuilder, DistinctQueryBuilder, normalize_str};
 pub use self::store::Store;
 
 /// Represent an internally generated document unique identifier.

--- a/meilidb-core/src/lib.rs
+++ b/meilidb-core/src/lib.rs
@@ -10,7 +10,7 @@ pub mod criterion;
 use std::fmt;
 use std::sync::Arc;
 
-use rayon::slice::ParallelSliceMut;
+use sdset::SetBuf;
 use serde::{Serialize, Deserialize};
 use slice_group_by::GroupBy;
 use zerocopy::{AsBytes, FromBytes};
@@ -229,11 +229,9 @@ impl fmt::Debug for RawDocument {
     }
 }
 
-pub fn raw_documents_from_matches(mut matches: Vec<(DocumentId, Match)>) -> Vec<RawDocument> {
-    let mut docs_ranges = Vec::<(DocumentId, Range)>::new();
+pub fn raw_documents_from_matches(matches: SetBuf<(DocumentId, Match)>) -> Vec<RawDocument> {
+    let mut docs_ranges = Vec::<(_, Range)>::new();
     let mut matches2 = Matches::with_capacity(matches.len());
-
-    matches.par_sort_unstable();
 
     for group in matches.linear_group_by(|(a, _), (b, _)| a == b) {
         let id = group[0].0;

--- a/meilidb-core/src/query_builder.rs
+++ b/meilidb-core/src/query_builder.rs
@@ -45,7 +45,7 @@ fn generate_automatons<S: Store>(query: &str, store: &S) -> Result<Vec<(usize, D
                     while let Some(synonyms) = stream.next() {
                         let synonyms = std::str::from_utf8(synonyms).unwrap();
                         for synonym in split_query_string(synonyms) {
-                            let lev = if not_prefix_dfa { build_dfa(synonym) } else { build_prefix_dfa(synonym) };
+                            let lev = build_dfa(synonym);
                             automatons.push((index, synonym.to_owned(), lev));
                         }
                     }

--- a/meilidb-core/src/store.rs
+++ b/meilidb-core/src/store.rs
@@ -8,6 +8,9 @@ pub trait Store {
 
     fn words(&self) -> Result<&Set, Self::Error>;
     fn word_indexes(&self, word: &[u8]) -> Result<Option<SetBuf<DocIndex>>, Self::Error>;
+
+    fn synonyms(&self) -> Result<&Set, Self::Error>;
+    fn alternatives_to(&self, word: &[u8]) -> Result<Option<Set>, Self::Error>;
 }
 
 impl<T> Store for &'_ T where T: Store {
@@ -19,5 +22,13 @@ impl<T> Store for &'_ T where T: Store {
 
     fn word_indexes(&self, word: &[u8]) -> Result<Option<SetBuf<DocIndex>>, Self::Error> {
         (*self).word_indexes(word)
+    }
+
+    fn synonyms(&self) -> Result<&Set, Self::Error> {
+        (*self).synonyms()
+    }
+
+    fn alternatives_to(&self, word: &[u8]) -> Result<Option<Set>, Self::Error> {
+        (*self).alternatives_to(word)
     }
 }

--- a/meilidb-data/src/database/documents_addition.rs
+++ b/meilidb-data/src/database/documents_addition.rs
@@ -120,11 +120,12 @@ impl<'a> DocumentsAddition<'a> {
 
         // update the "consistent" view of the Index
         let ranked_map = self.ranked_map;
+        let synonyms = fst::Set::from_bytes(lease_inner.synonyms.as_fst().to_vec()).unwrap(); // clone()
         let schema = lease_inner.schema.clone();
         let raw = lease_inner.raw.clone();
         lease_inner.raw.compact();
 
-        let inner = InnerIndex { words, schema, ranked_map, raw };
+        let inner = InnerIndex { words, synonyms, schema, ranked_map, raw };
         self.inner.0.store(Arc::new(inner));
 
         Ok(())

--- a/meilidb-data/src/database/documents_deletion.rs
+++ b/meilidb-data/src/database/documents_deletion.rs
@@ -119,11 +119,12 @@ impl<'a> DocumentsDeletion<'a> {
 
         // update the "consistent" view of the Index
         let ranked_map = lease_inner.ranked_map.clone();
+        let synonyms = fst::Set::from_bytes(lease_inner.synonyms.as_fst().to_vec()).unwrap(); // clone()
         let schema = lease_inner.schema.clone();
         let raw = lease_inner.raw.clone();
         lease_inner.raw.compact();
 
-        let inner = InnerIndex { words, schema, ranked_map, raw };
+        let inner = InnerIndex { words, synonyms, schema, ranked_map, raw };
         self.inner.0.store(Arc::new(inner));
 
         Ok(())

--- a/meilidb-data/src/database/main_index.rs
+++ b/meilidb-data/src/database/main_index.rs
@@ -44,6 +44,22 @@ impl MainIndex {
         self.0.set("words", value.as_fst().as_bytes()).map_err(Into::into)
     }
 
+    pub fn synonyms_set(&self) -> Result<Option<fst::Set>, Error> {
+        match self.0.get_pinned("synonyms")? {
+            Some(bytes) => {
+                let len = bytes.len();
+                let value = Arc::from(bytes.as_ref());
+                let fst = fst::raw::Fst::from_shared_bytes(value, 0, len)?;
+                Ok(Some(fst::Set::from(fst)))
+            },
+            None => Ok(None),
+        }
+    }
+
+    pub fn set_synonyms_set(&self, value: &fst::Set) -> Result<(), Error> {
+        self.0.set("synonyms", value.as_fst().as_bytes()).map_err(Into::into)
+    }
+
     pub fn ranked_map(&self) -> Result<Option<RankedMap>, Error> {
         match self.0.get_pinned("ranked-map")? {
             Some(bytes) => {

--- a/meilidb-data/src/database/raw_index.rs
+++ b/meilidb-data/src/database/raw_index.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
-use super::{MainIndex, WordsIndex, DocsWordsIndex, DocumentsIndex, CustomSettings};
+use super::{MainIndex, SynonymsIndex, WordsIndex, DocsWordsIndex, DocumentsIndex, CustomSettings};
 
 #[derive(Clone)]
 pub struct RawIndex {
     pub main: MainIndex,
+    pub synonyms: SynonymsIndex,
     pub words: WordsIndex,
     pub docs_words: DocsWordsIndex,
     pub documents: DocumentsIndex,
@@ -13,6 +14,7 @@ pub struct RawIndex {
 impl RawIndex {
     pub(crate) fn compact(&self) {
         self.main.0.compact_range(None::<&[u8]>, None::<&[u8]>);
+        self.synonyms.0.compact_range(None::<&[u8]>, None::<&[u8]>);
         self.words.0.compact_range(None::<&[u8]>, None::<&[u8]>);
         self.docs_words.0.compact_range(None::<&[u8]>, None::<&[u8]>);
         self.documents.0.compact_range(None::<&[u8]>, None::<&[u8]>);

--- a/meilidb-data/src/database/synonyms_addition.rs
+++ b/meilidb-data/src/database/synonyms_addition.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use fst::{SetBuilder, set::OpBuilder};
-use meilidb_tokenizer::is_cjk;
 use meilidb_core::normalize_str;
 use sdset::SetBuf;
 
@@ -19,11 +18,13 @@ impl<'a> SynonymsAddition<'a> {
         SynonymsAddition { inner, synonyms: BTreeMap::new() }
     }
 
-    pub fn add_synonym<I>(&mut self, synonym: String, alternatives: I)
-    where I: Iterator<Item=String>,
+    pub fn add_synonym<S, T, I>(&mut self, synonym: S, alternatives: I)
+    where S: AsRef<str>,
+          T: AsRef<str>,
+          I: Iterator<Item=T>,
     {
-        let mut synonym = normalize_str(&synonym);
-        let alternatives = alternatives.map(|s| s.to_lowercase());
+        let synonym = normalize_str(synonym.as_ref());
+        let alternatives = alternatives.map(|s| s.as_ref().to_lowercase());
         self.synonyms.entry(synonym).or_insert_with(Vec::new).extend(alternatives);
     }
 

--- a/meilidb-data/src/database/synonyms_addition.rs
+++ b/meilidb-data/src/database/synonyms_addition.rs
@@ -1,0 +1,83 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use fst::{SetBuilder, set::OpBuilder};
+use sdset::SetBuf;
+
+use crate::database::index::InnerIndex;
+use super::{Error, Index};
+
+pub struct SynonymsAddition<'a> {
+    inner: &'a Index,
+    synonyms: BTreeMap<String, Vec<String>>,
+}
+
+impl<'a> SynonymsAddition<'a> {
+    pub fn new(inner: &'a Index) -> SynonymsAddition<'a> {
+        SynonymsAddition { inner, synonyms: BTreeMap::new() }
+    }
+
+    pub fn add_synonym<I>(&mut self, synonym: String, alternatives: I)
+    where I: Iterator<Item=String>,
+    {
+        self.synonyms.entry(synonym).or_insert_with(Vec::new).extend(alternatives);
+    }
+
+    pub fn finalize(self) -> Result<(), Error> {
+        let lease_inner = self.inner.lease_inner();
+        let synonyms = &lease_inner.raw.synonyms;
+        let main = &lease_inner.raw.main;
+
+        let mut synonyms_builder = SetBuilder::memory();
+
+        for (synonym, mut alternatives) in self.synonyms {
+            synonyms_builder.insert(&synonym).unwrap();
+
+            let alternatives = {
+                alternatives.iter_mut().for_each(|s| *s = s.to_lowercase());
+                let alternatives = SetBuf::from_dirty(alternatives);
+
+                let mut alternatives_builder = SetBuilder::memory();
+                alternatives_builder.extend_iter(alternatives).unwrap();
+                alternatives_builder.into_inner().unwrap()
+            };
+            synonyms.set_alternatives_to(synonym.as_bytes(), alternatives)?;
+        }
+
+        let delta_synonyms = synonyms_builder
+            .into_inner()
+            .and_then(fst::Set::from_bytes)
+            .unwrap();
+
+        let synonyms = match main.synonyms_set()? {
+            Some(synonyms) => {
+                let op = OpBuilder::new()
+                    .add(synonyms.stream())
+                    .add(delta_synonyms.stream())
+                    .r#union();
+
+                let mut synonyms_builder = SetBuilder::memory();
+                synonyms_builder.extend_stream(op).unwrap();
+                synonyms_builder
+                    .into_inner()
+                    .and_then(fst::Set::from_bytes)
+                    .unwrap()
+            },
+            None => delta_synonyms,
+        };
+
+        main.set_synonyms_set(&synonyms)?;
+
+        // update the "consistent" view of the Index
+        let words = main.words_set()?.unwrap_or_default();
+        let ranked_map = lease_inner.ranked_map.clone();;
+        let schema = lease_inner.schema.clone();
+        let raw = lease_inner.raw.clone();
+        lease_inner.raw.compact();
+
+        let inner = InnerIndex { words, synonyms, schema, ranked_map, raw };
+        self.inner.0.store(Arc::new(inner));
+
+        Ok(())
+    }
+}

--- a/meilidb-data/src/database/synonyms_deletion.rs
+++ b/meilidb-data/src/database/synonyms_deletion.rs
@@ -1,23 +1,41 @@
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
+use std::iter::FromIterator;
 use std::sync::Arc;
 
 use fst::{SetBuilder, set::OpBuilder};
+use meilidb_core::normalize_str;
+use sdset::SetBuf;
 
 use crate::database::index::InnerIndex;
 use super::{Error, Index};
 
 pub struct SynonymsDeletion<'a> {
     inner: &'a Index,
-    synonyms: BTreeSet<String>,
+    synonyms: BTreeMap<String, Option<Vec<String>>>,
 }
 
 impl<'a> SynonymsDeletion<'a> {
     pub fn new(inner: &'a Index) -> SynonymsDeletion<'a> {
-        SynonymsDeletion { inner, synonyms: BTreeSet::new() }
+        SynonymsDeletion { inner, synonyms: BTreeMap::new() }
     }
 
-    pub fn delete_alternatives_of<I>(&mut self, synonym: String) {
-        self.synonyms.insert(synonym);
+    pub fn delete_all_alternatives_of<S: AsRef<str>>(&mut self, synonym: S) {
+        let synonym = normalize_str(synonym.as_ref());
+        self.synonyms.insert(synonym, None);
+    }
+
+    pub fn delete_specific_alternatives_of<S, T, I>(&mut self, synonym: S, alternatives: I)
+    where S: AsRef<str>,
+          T: AsRef<str>,
+          I: Iterator<Item=T>,
+    {
+        let synonym = normalize_str(synonym.as_ref());
+        let value = self.synonyms.entry(synonym).or_insert(None);
+        let alternatives = alternatives.map(|s| s.as_ref().to_lowercase());
+        match value {
+            Some(v) => v.extend(alternatives),
+            None => *value = Some(Vec::from_iter(alternatives)),
+        }
     }
 
     pub fn finalize(self) -> Result<(), Error> {
@@ -25,14 +43,54 @@ impl<'a> SynonymsDeletion<'a> {
         let synonyms = &lease_inner.raw.synonyms;
         let main = &lease_inner.raw.main;
 
-        let mut synonyms_builder = SetBuilder::memory();
+        let mut delete_whole_synonym_builder = SetBuilder::memory();
 
-        for synonym in self.synonyms {
-            synonyms_builder.insert(&synonym).unwrap();
-            synonyms.del_alternatives_of(synonym.as_bytes())?;
+        for (synonym, alternatives) in self.synonyms {
+            match alternatives {
+                Some(alternatives) => {
+                    let prev_alternatives = synonyms.alternatives_to(synonym.as_bytes())?;
+                    let prev_alternatives = match prev_alternatives {
+                        Some(alternatives) => alternatives,
+                        None => continue,
+                    };
+
+                    let delta_alternatives = {
+                        let alternatives = SetBuf::from_dirty(alternatives);
+                        let mut builder = SetBuilder::memory();
+                        builder.extend_iter(alternatives).unwrap();
+                        builder.into_inner()
+                            .and_then(fst::Set::from_bytes)
+                            .unwrap()
+                    };
+
+                    let op = OpBuilder::new()
+                        .add(prev_alternatives.stream())
+                        .add(delta_alternatives.stream())
+                        .difference();
+
+                    let (alternatives, empty_alternatives) = {
+                        let mut builder = SetBuilder::memory();
+                        let len = builder.get_ref().len();
+                        builder.extend_stream(op).unwrap();
+                        let is_empty = len == builder.get_ref().len();
+                        let alternatives = builder.into_inner().unwrap();
+                        (alternatives, is_empty)
+                    };
+
+                    if empty_alternatives {
+                        delete_whole_synonym_builder.insert(synonym.as_bytes())?;
+                    } else {
+                        synonyms.set_alternatives_to(synonym.as_bytes(), alternatives)?;
+                    }
+                },
+                None => {
+                    delete_whole_synonym_builder.insert(&synonym).unwrap();
+                    synonyms.del_alternatives_of(synonym.as_bytes())?;
+                }
+            }
         }
 
-        let delta_synonyms = synonyms_builder
+        let delta_synonyms = delete_whole_synonym_builder
             .into_inner()
             .and_then(fst::Set::from_bytes)
             .unwrap();

--- a/meilidb-data/src/database/synonyms_deletion.rs
+++ b/meilidb-data/src/database/synonyms_deletion.rs
@@ -1,0 +1,71 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use fst::{SetBuilder, set::OpBuilder};
+
+use crate::database::index::InnerIndex;
+use super::{Error, Index};
+
+pub struct SynonymsDeletion<'a> {
+    inner: &'a Index,
+    synonyms: BTreeSet<String>,
+}
+
+impl<'a> SynonymsDeletion<'a> {
+    pub fn new(inner: &'a Index) -> SynonymsDeletion<'a> {
+        SynonymsDeletion { inner, synonyms: BTreeSet::new() }
+    }
+
+    pub fn delete_alternatives_of<I>(&mut self, synonym: String) {
+        self.synonyms.insert(synonym);
+    }
+
+    pub fn finalize(self) -> Result<(), Error> {
+        let lease_inner = self.inner.lease_inner();
+        let synonyms = &lease_inner.raw.synonyms;
+        let main = &lease_inner.raw.main;
+
+        let mut synonyms_builder = SetBuilder::memory();
+
+        for synonym in self.synonyms {
+            synonyms_builder.insert(&synonym).unwrap();
+            synonyms.del_alternatives_of(synonym.as_bytes())?;
+        }
+
+        let delta_synonyms = synonyms_builder
+            .into_inner()
+            .and_then(fst::Set::from_bytes)
+            .unwrap();
+
+        let synonyms = match main.synonyms_set()? {
+            Some(synonyms) => {
+                let op = OpBuilder::new()
+                    .add(synonyms.stream())
+                    .add(delta_synonyms.stream())
+                    .difference();
+
+                let mut synonyms_builder = SetBuilder::memory();
+                synonyms_builder.extend_stream(op).unwrap();
+                synonyms_builder
+                    .into_inner()
+                    .and_then(fst::Set::from_bytes)
+                    .unwrap()
+            },
+            None => fst::Set::default(),
+        };
+
+        main.set_synonyms_set(&synonyms)?;
+
+        // update the "consistent" view of the Index
+        let words = main.words_set()?.unwrap_or_default();
+        let ranked_map = lease_inner.ranked_map.clone();
+        let schema = lease_inner.schema.clone();
+        let raw = lease_inner.raw.clone();
+        lease_inner.raw.compact();
+
+        let inner = InnerIndex { words, synonyms, schema, ranked_map, raw };
+        self.inner.0.store(Arc::new(inner));
+
+        Ok(())
+    }
+}

--- a/meilidb-data/src/database/synonyms_index.rs
+++ b/meilidb-data/src/database/synonyms_index.rs
@@ -1,0 +1,23 @@
+use crate::database::raw_index::InnerRawIndex;
+
+#[derive(Clone)]
+pub struct SynonymsIndex(pub(crate) InnerRawIndex);
+
+impl SynonymsIndex {
+    pub fn alternatives_to(&self, word: &[u8]) -> Result<Option<fst::Set>, rocksdb::Error> {
+        match self.0.get(word)? {
+            Some(vector) => Ok(Some(fst::Set::from_bytes(vector.to_vec()).unwrap())),
+            None => Ok(None),
+        }
+    }
+
+    pub fn set_alternatives_to(&self, word: &[u8], value: Vec<u8>) -> Result<(), rocksdb::Error> {
+        self.0.set(word, value)?;
+        Ok(())
+    }
+
+    pub fn del_alternatives_of(&self, word: &[u8]) -> Result<(), rocksdb::Error> {
+        self.0.delete(word)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This pull request make the engine support the multi-word has multi-word alternatives, it is limited to 3 words for base words.

`"NY"` has these alternatives: `"NYC"`, `"new york"`, `"new york city"`
`"NYC"` has these alternatives: `"NY"`,  `"new york"`, `"new york city"`
`"subway"` has these alternatives: `"underground train"`
`"new york"` has these alternatives: `"NY"`, `"NYC"`, `"new york city"`
`"new york city"` has these alternatives: `"NY"`, `"NYC"`, `"new york"`