### PR TITLE
Transform identifiers fields into a string before hashing it

### DIFF
--- a/meilidb-data/Cargo.toml
+++ b/meilidb-data/Cargo.toml
@@ -15,7 +15,8 @@ meilidb-tokenizer = { path = "../meilidb-tokenizer", version = "0.1.0" }
 ordered-float = { version = "1.0.2", features = ["serde"] }
 rocksdb = { version = "0.12.2", default-features = false }
 sdset = "0.3.2"
-serde = { version = "1.0.91", features = ["derive"] }
+serde = { version = "1.0.99", features = ["derive"] }
+serde_json = "1.0.40"
 siphasher = "0.3.0"
 zerocopy = "0.2.2"
 
@@ -29,4 +30,3 @@ branch = "arc-byte-slice"
 
 [dev-dependencies]
 tempfile = "3.0.7"
-serde_json = "1.0.39"


### PR DESCRIPTION
This way it is possible to retrieve a document by its id using a string value without knowing the original document identifier type because it will always interpret it as a string.