### PR TITLE
Do not commit updates, let the user do

### DIFF
--- a/meilidb-core/src/store/mod.rs
+++ b/meilidb-core/src/store/mod.rs
@@ -109,10 +109,9 @@ impl Index {
         }
     }
 
-    pub fn schema_update(&self, mut writer: rkv::Writer, schema: Schema) -> MResult<()> {
-        update::push_schema_update(&mut writer, self.updates, self.updates_results, schema)?;
-        writer.commit()?;
+    pub fn schema_update(&self, writer: &mut rkv::Writer, schema: Schema) -> MResult<()> {
         let _ = self.updates_notifier.send(());
+        update::push_schema_update(writer, self.updates, self.updates_results, schema)?;
         Ok(())
     }
 

--- a/meilidb-core/src/update/documents_addition.rs
+++ b/meilidb-core/src/update/documents_addition.rs
@@ -36,18 +36,16 @@ impl<D> DocumentsAddition<D> {
         self.documents.push(document);
     }
 
-    pub fn finalize(self, mut writer: rkv::Writer) -> MResult<u64>
+    pub fn finalize(self, writer: &mut rkv::Writer) -> MResult<u64>
     where D: serde::Serialize
     {
+        let _ = self.updates_notifier.send(());
         let update_id = push_documents_addition(
-            &mut writer,
+            writer,
             self.updates_store,
             self.updates_results_store,
             self.documents,
         )?;
-        writer.commit()?;
-        let _ = self.updates_notifier.send(());
-
         Ok(update_id)
     }
 }

--- a/meilidb-core/src/update/documents_deletion.rs
+++ b/meilidb-core/src/update/documents_deletion.rs
@@ -49,16 +49,14 @@ impl DocumentsDeletion {
         Ok(())
     }
 
-    pub fn finalize(self, mut writer: rkv::Writer) -> MResult<u64> {
+    pub fn finalize(self, writer: &mut rkv::Writer) -> MResult<u64> {
+        let _ = self.updates_notifier.send(());
         let update_id = push_documents_deletion(
-            &mut writer,
+            writer,
             self.updates_store,
             self.updates_results_store,
             self.documents,
         )?;
-        writer.commit()?;
-        let _ = self.updates_notifier.send(());
-
         Ok(update_id)
     }
 }

--- a/meilidb-core/src/update/synonyms_addition.rs
+++ b/meilidb-core/src/update/synonyms_addition.rs
@@ -39,16 +39,14 @@ impl SynonymsAddition {
         self.synonyms.entry(synonym).or_insert_with(Vec::new).extend(alternatives);
     }
 
-    pub fn finalize(self, mut writer: rkv::Writer) -> MResult<u64> {
+    pub fn finalize(self, writer: &mut rkv::Writer) -> MResult<u64> {
+        let _ = self.updates_notifier.send(());
         let update_id = push_synonyms_addition(
-            &mut writer,
+            writer,
             self.updates_store,
             self.updates_results_store,
             self.synonyms,
         )?;
-        writer.commit()?;
-        let _ = self.updates_notifier.send(());
-
         Ok(update_id)
     }
 }

--- a/meilidb-core/src/update/synonyms_deletion.rs
+++ b/meilidb-core/src/update/synonyms_deletion.rs
@@ -49,16 +49,14 @@ impl SynonymsDeletion {
         }
     }
 
-    pub fn finalize(self, mut writer: rkv::Writer) -> MResult<u64> {
+    pub fn finalize(self, writer: &mut rkv::Writer) -> MResult<u64> {
+        let _ = self.updates_notifier.send(());
         let update_id = push_synonyms_deletion(
-            &mut writer,
+            writer,
             self.updates_store,
             self.updates_results_store,
             self.synonyms,
         )?;
-        writer.commit()?;
-        let _ = self.updates_notifier.send(());
-
         Ok(update_id)
     }
 }


### PR DESCRIPTION
We must not give a transaction to the update system, we better must ask for a `&mut Txn` and let the user commit its transaction itself.