### PR TITLE
Get ride of rust messagepack (rmp)

### DIFF
--- a/meilidb-core/Cargo.toml
+++ b/meilidb-core/Cargo.toml
@@ -20,20 +20,11 @@ once_cell = "1.2.0"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 rkv = "0.10.2"
 sdset = "0.3.2"
-serde = { version = "1.0.99", features = ["derive"] }
-serde_json = "1.0.40"
+serde = { version = "1.0.101", features = ["derive"] }
+serde_json = "1.0.41"
 siphasher = "0.3.0"
 slice-group-by = "0.2.6"
 zerocopy = "0.2.8"
-
-[dependencies.rmp-serde]
-git = "https://github.com/3Hren/msgpack-rust.git"
-rev = "40b3d48"
-
-[dependencies.rmpv]
-git = "https://github.com/3Hren/msgpack-rust.git"
-rev = "40b3d48"
-features = ["with-serde"]
 
 [dependencies.levenshtein_automata]
 git = "https://github.com/Kerollmops/levenshtein-automata.git"

--- a/meilidb-core/src/error.rs
+++ b/meilidb-core/src/error.rs
@@ -1,4 +1,5 @@
 use std::{error, fmt, io};
+use serde_json::Error as SerdeJsonError;
 use crate::serde::{SerializerError, DeserializerError};
 
 pub type MResult<T> = Result<T, Error>;
@@ -13,8 +14,7 @@ pub enum Error {
     MissingDocumentId,
     Rkv(rkv::StoreError),
     Fst(fst::Error),
-    RmpDecode(rmp_serde::decode::Error),
-    RmpEncode(rmp_serde::encode::Error),
+    SerdeJson(SerdeJsonError),
     Bincode(bincode::Error),
     Serializer(SerializerError),
     Deserializer(DeserializerError),
@@ -39,15 +39,9 @@ impl From<fst::Error> for Error {
     }
 }
 
-impl From<rmp_serde::decode::Error> for Error {
-    fn from(error: rmp_serde::decode::Error) -> Error {
-        Error::RmpDecode(error)
-    }
-}
-
-impl From<rmp_serde::encode::Error> for Error {
-    fn from(error: rmp_serde::encode::Error) -> Error {
-        Error::RmpEncode(error)
+impl From<SerdeJsonError> for Error {
+    fn from(error: SerdeJsonError) -> Error {
+        Error::SerdeJson(error)
     }
 }
 
@@ -87,8 +81,7 @@ impl fmt::Display for Error {
             MissingDocumentId => write!(f, "document id is missing"),
             Rkv(e) => write!(f, "rkv error; {}", e),
             Fst(e) => write!(f, "fst error; {}", e),
-            RmpDecode(e) => write!(f, "rmp decode error; {}", e),
-            RmpEncode(e) => write!(f, "rmp encode error; {}", e),
+            SerdeJson(e) => write!(f, "serde json error; {}", e),
             Bincode(e) => write!(f, "bincode error; {}", e),
             Serializer(e) => write!(f, "serializer error; {}", e),
             Deserializer(e) => write!(f, "deserializer error; {}", e),

--- a/meilidb-core/src/serde/serializer.rs
+++ b/meilidb-core/src/serde/serializer.rs
@@ -270,7 +270,7 @@ where T: ser::Serialize,
     if let Some(attribute) = schema.attribute(key) {
         let props = schema.props(attribute);
 
-        let serialized = rmp_serde::to_vec_named(value)?;
+        let serialized = serde_json::to_vec(value)?;
         document_store.set_document_field(document_id, attribute, serialized);
 
         if props.is_indexed() {

--- a/meilidb-core/src/store/mod.rs
+++ b/meilidb-core/src/store/mod.rs
@@ -104,7 +104,7 @@ impl Index {
     {
         let bytes = self.documents_fields.document_attribute(reader, document_id, attribute)?;
         match bytes {
-            Some(bytes) => Ok(Some(rmp_serde::from_read_ref(bytes)?)),
+            Some(bytes) => Ok(Some(serde_json::from_slice(bytes)?)),
             None => Ok(None),
         }
     }

--- a/meilidb-core/src/store/updates.rs
+++ b/meilidb-core/src/store/updates.rs
@@ -68,7 +68,7 @@ impl Updates {
     ) -> MResult<()>
     {
         let update_id_bytes = update_id.to_be_bytes();
-        let update = rmp_serde::to_vec_named(&update)?;
+        let update = serde_json::to_vec(&update)?;
         let blob = Value::Blob(&update);
         self.updates.put(writer, update_id_bytes, &blob)?;
         Ok(())
@@ -86,8 +86,7 @@ impl Updates {
 
         match first_data {
             Some(Value::Blob(bytes)) => {
-                let update = rmp_serde::from_read_ref(&bytes)?;
-
+                let update = serde_json::from_slice(&bytes)?;
                 // remove it from the database now
                 let first_id_bytes = first_id.to_be_bytes();
                 self.updates.delete(writer, first_id_bytes)?;

--- a/meilidb-core/src/update/documents_addition.rs
+++ b/meilidb-core/src/update/documents_addition.rs
@@ -65,8 +65,8 @@ pub fn push_documents_addition<D: serde::Serialize>(
 {
     let mut values = Vec::with_capacity(addition.len());
     for add in addition {
-        let vec = rmp_serde::to_vec_named(&add)?;
-        let add = rmp_serde::from_read(&vec[..])?;
+        let vec = serde_json::to_vec(&add)?;
+        let add = serde_json::from_slice(&vec)?;
         values.push(add);
     }
 
@@ -85,7 +85,7 @@ pub fn apply_documents_addition(
     postings_lists_store: store::PostingsLists,
     docs_words_store: store::DocsWords,
     mut ranked_map: RankedMap,
-    addition: Vec<rmpv::Value>,
+    addition: Vec<serde_json::Value>,
 ) -> MResult<()>
 {
     let mut document_ids = HashSet::new();

--- a/meilidb-core/src/update/mod.rs
+++ b/meilidb-core/src/update/mod.rs
@@ -26,7 +26,7 @@ use meilidb_schema::Schema;
 pub enum Update {
     Schema(Schema),
     Customs(Vec<u8>),
-    DocumentsAddition(Vec<rmpv::Value>),
+    DocumentsAddition(Vec<serde_json::Value>),
     DocumentsDeletion(Vec<DocumentId>),
     SynonymsAddition(BTreeMap<String, Vec<String>>),
     SynonymsDeletion(BTreeMap<String, Option<Vec<String>>>),


### PR DESCRIPTION
I tried to use the [`serde_json::Deserializer::from_slice`](https://docs.rs/serde_json/1.0.41/serde_json/struct.Deserializer.html#method.from_slice) constructor instead of the "owned" one but didn't achieved to do so... It would have been better because less code would have been duplicated.