### PR TITLE
Make the levenshtein algorithm consider transpositions to cost 1

### DIFF
--- a/meilidb-core/src/automaton/dfa.rs
+++ b/meilidb-core/src/automaton/dfa.rs
@@ -19,21 +19,21 @@ fn build_dfa_with_setting(query: &str, setting: PrefixSetting) -> DFA {
 
     match query.len() {
         0 ..= 4 => {
-            let builder = LEVDIST0.get_or_init(|| LevBuilder::new(0, false));
+            let builder = LEVDIST0.get_or_init(|| LevBuilder::new(0, true));
             match setting {
                 Prefix   => builder.build_prefix_dfa(query),
                 NoPrefix => builder.build_dfa(query),
             }
         },
         5 ..= 8 => {
-            let builder = LEVDIST1.get_or_init(|| LevBuilder::new(1, false));
+            let builder = LEVDIST1.get_or_init(|| LevBuilder::new(1, true));
             match setting {
                 Prefix   => builder.build_prefix_dfa(query),
                 NoPrefix => builder.build_dfa(query),
             }
         },
         _ => {
-            let builder = LEVDIST2.get_or_init(|| LevBuilder::new(2, false));
+            let builder = LEVDIST2.get_or_init(|| LevBuilder::new(2, true));
             match setting {
                 Prefix   => builder.build_prefix_dfa(query),
                 NoPrefix => builder.build_dfa(query),


### PR DESCRIPTION
This gives better results when typing "botos" instead of "boots" for example.