### PR TITLE
Fix dead locks

### DIFF
--- a/meilidb-core/src/database.rs
+++ b/meilidb-core/src/database.rs
@@ -35,10 +35,13 @@ fn update_awaiter(receiver: Receiver<()>, env: heed::Env, update_fn: Arc<ArcSwap
 
             match update::update_task(&mut writer, index.clone()) {
                 Ok(Some(status)) => {
-                    if status.result.is_ok() {
-                        if let Err(e) = writer.commit() {
-                            error!("update transaction failed: {}", e)
+                    match status.result {
+                        Ok(_) => {
+                            if let Err(e) = writer.commit() {
+                                error!("update transaction failed: {}", e)
+                            }
                         }
+                        Err(_) => writer.abort(),
                     }
 
                     if let Some(ref callback) = *update_fn.load() {

--- a/meilidb-core/src/store/mod.rs
+++ b/meilidb-core/src/store/mod.rs
@@ -167,6 +167,7 @@ impl Index {
     }
 
     pub fn clear_all(&self, writer: &mut heed::RwTxn) -> MResult<u64> {
+        let _ = self.updates_notifier.send(());
         update::push_clear_all(writer, self.updates, self.updates_results)
     }
 


### PR DESCRIPTION
There were a potential dead lock caused by us trying to begin a write transaction in the update callback and did not abort the update transaction before calling that update. This could happen when updates were unsuccessful.

We also forgot to send channel updates to the update loop when clearing all documents.