### PR TITLE
Fix the updates system

### DIFF
--- a/meilidb-core/Cargo.toml
+++ b/meilidb-core/Cargo.toml
@@ -12,7 +12,7 @@ crossbeam-channel = "0.3.9"
 deunicode = "1.0.0"
 env_logger = "0.7.0"
 hashbrown = { version = "0.6.0", features = ["serde"] }
-heed = "0.3.1"
+heed = "0.5.0"
 log = "0.4.8"
 meilidb-schema = { path = "../meilidb-schema", version = "0.6.0" }
 meilidb-tokenizer = { path = "../meilidb-tokenizer", version = "0.6.0" }

--- a/meilidb-core/Cargo.toml
+++ b/meilidb-core/Cargo.toml
@@ -12,7 +12,7 @@ crossbeam-channel = "0.3.9"
 deunicode = "1.0.0"
 env_logger = "0.7.0"
 hashbrown = { version = "0.6.0", features = ["serde"] }
-heed = "0.3.0"
+heed = "0.3.1"
 log = "0.4.8"
 meilidb-schema = { path = "../meilidb-schema", version = "0.6.0" }
 meilidb-tokenizer = { path = "../meilidb-tokenizer", version = "0.6.0" }

--- a/meilidb-core/src/database.rs
+++ b/meilidb-core/src/database.rs
@@ -7,7 +7,7 @@ use std::{fs, thread};
 use crossbeam_channel::Receiver;
 use heed::types::{Str, Unit};
 use heed::{CompactionOption, Result as ZResult};
-use log::{debug, error};
+use log::debug;
 
 use crate::{store, update, Index, MResult};
 
@@ -220,5 +220,143 @@ impl Database {
 
     pub fn common_store(&self) -> heed::PolyDatabase {
         self.common_store
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::update::{ProcessedUpdateResult, UpdateStatus};
+    use std::sync::mpsc;
+
+    #[test]
+    fn valid_updates() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let database = Database::open_or_create(dir.path()).unwrap();
+        let env = &database.env;
+
+        let (sender, receiver) = mpsc::sync_channel(100);
+        let update_fn = move |update: ProcessedUpdateResult| sender.send(update.update_id).unwrap();
+        let index = database.create_index("test").unwrap();
+
+        let done = database.set_update_callback("test", Box::new(update_fn));
+        assert!(done, "could not set the index update function");
+
+        let schema = {
+            let data = r#"
+                identifier = "id"
+
+                [attributes."name"]
+                displayed = true
+                indexed = true
+
+                [attributes."description"]
+                displayed = true
+                indexed = true
+            "#;
+            toml::from_str(data).unwrap()
+        };
+
+        let mut writer = env.write_txn().unwrap();
+        let _update_id = index.schema_update(&mut writer, schema).unwrap();
+
+        // don't forget to commit...
+        writer.commit().unwrap();
+
+        let mut additions = index.documents_addition();
+
+        let doc1 = serde_json::json!({
+            "id": 123,
+            "name": "Marvin",
+            "description": "My name is Marvin",
+        });
+
+        let doc2 = serde_json::json!({
+            "id": 234,
+            "name": "Kevin",
+            "description": "My name is Kevin",
+        });
+
+        additions.update_document(doc1);
+        additions.update_document(doc2);
+
+        let mut writer = env.write_txn().unwrap();
+        let update_id = additions.finalize(&mut writer).unwrap();
+
+        // don't forget to commit...
+        writer.commit().unwrap();
+
+        // block until the transaction is processed
+        let _ = receiver.into_iter().find(|id| *id == update_id);
+
+        let reader = env.read_txn().unwrap();
+        let result = index.update_status(&reader, update_id).unwrap();
+        assert_matches!(result, UpdateStatus::Processed(status) if status.result.is_ok());
+    }
+
+    #[test]
+    fn invalid_updates() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let database = Database::open_or_create(dir.path()).unwrap();
+        let env = &database.env;
+
+        let (sender, receiver) = mpsc::sync_channel(100);
+        let update_fn = move |update: ProcessedUpdateResult| sender.send(update.update_id).unwrap();
+        let index = database.create_index("test").unwrap();
+
+        let done = database.set_update_callback("test", Box::new(update_fn));
+        assert!(done, "could not set the index update function");
+
+        let schema = {
+            let data = r#"
+                identifier = "id"
+
+                [attributes."name"]
+                displayed = true
+                indexed = true
+
+                [attributes."description"]
+                displayed = true
+                indexed = true
+            "#;
+            toml::from_str(data).unwrap()
+        };
+
+        let mut writer = env.write_txn().unwrap();
+        let _update_id = index.schema_update(&mut writer, schema).unwrap();
+
+        // don't forget to commit...
+        writer.commit().unwrap();
+
+        let mut additions = index.documents_addition();
+
+        let doc1 = serde_json::json!({
+            "id": 123,
+            "name": "Marvin",
+            "description": "My name is Marvin",
+        });
+
+        let doc2 = serde_json::json!({
+            "name": "Kevin",
+            "description": "My name is Kevin",
+        });
+
+        additions.update_document(doc1);
+        additions.update_document(doc2);
+
+        let mut writer = env.write_txn().unwrap();
+        let update_id = additions.finalize(&mut writer).unwrap();
+
+        // don't forget to commit...
+        writer.commit().unwrap();
+
+        // block until the transaction is processed
+        let _ = receiver.into_iter().find(|id| *id == update_id);
+
+        let reader = env.read_txn().unwrap();
+        let result = index.update_status(&reader, update_id).unwrap();
+        assert_matches!(result, UpdateStatus::Processed(status) if status.result.is_err());
     }
 }

--- a/meilidb-core/src/database.rs
+++ b/meilidb-core/src/database.rs
@@ -46,7 +46,7 @@ fn update_awaiter(receiver: Receiver<()>, env: heed::Env, update_fn: Arc<ArcSwap
                 }
             };
 
-            let mut nested_writer = match unsafe { env.nested_write_txn(&writer) } {
+            let mut nested_writer = match env.nested_write_txn(&mut writer) {
                 Ok(writer) => writer,
                 Err(e) => {
                     error!("LMDB nested write transaction begin failed: {}", e);

--- a/meilidb-core/src/serde/serializer.rs
+++ b/meilidb-core/src/serde/serializer.rs
@@ -7,8 +7,8 @@ use crate::{DocumentId, RankedMap};
 
 use super::{ConvertToNumber, ConvertToString, Indexer, SerializerError};
 
-pub struct Serializer<'a> {
-    pub txn: &'a mut heed::RwTxn,
+pub struct Serializer<'a, 'b> {
+    pub txn: &'a mut heed::RwTxn<'b>,
     pub schema: &'a Schema,
     pub document_store: DocumentsFields,
     pub document_fields_counts: DocumentsFieldsCounts,
@@ -17,15 +17,15 @@ pub struct Serializer<'a> {
     pub document_id: DocumentId,
 }
 
-impl<'a> ser::Serializer for Serializer<'a> {
+impl<'a, 'b> ser::Serializer for Serializer<'a, 'b> {
     type Ok = ();
     type Error = SerializerError;
     type SerializeSeq = ser::Impossible<Self::Ok, Self::Error>;
     type SerializeTuple = ser::Impossible<Self::Ok, Self::Error>;
     type SerializeTupleStruct = ser::Impossible<Self::Ok, Self::Error>;
     type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
-    type SerializeMap = MapSerializer<'a>;
-    type SerializeStruct = StructSerializer<'a>;
+    type SerializeMap = MapSerializer<'a, 'b>;
+    type SerializeStruct = StructSerializer<'a, 'b>;
     type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
 
     forward_to_unserializable_type! {
@@ -190,8 +190,8 @@ impl<'a> ser::Serializer for Serializer<'a> {
     }
 }
 
-pub struct MapSerializer<'a> {
-    txn: &'a mut heed::RwTxn,
+pub struct MapSerializer<'a, 'b> {
+    txn: &'a mut heed::RwTxn<'b>,
     schema: &'a Schema,
     document_id: DocumentId,
     document_store: DocumentsFields,
@@ -201,7 +201,7 @@ pub struct MapSerializer<'a> {
     current_key_name: Option<String>,
 }
 
-impl<'a> ser::SerializeMap for MapSerializer<'a> {
+impl<'a, 'b> ser::SerializeMap for MapSerializer<'a, 'b> {
     type Ok = ();
     type Error = SerializerError;
 
@@ -253,8 +253,8 @@ impl<'a> ser::SerializeMap for MapSerializer<'a> {
     }
 }
 
-pub struct StructSerializer<'a> {
-    txn: &'a mut heed::RwTxn,
+pub struct StructSerializer<'a, 'b> {
+    txn: &'a mut heed::RwTxn<'b>,
     schema: &'a Schema,
     document_id: DocumentId,
     document_store: DocumentsFields,
@@ -263,7 +263,7 @@ pub struct StructSerializer<'a> {
     ranked_map: &'a mut RankedMap,
 }
 
-impl<'a> ser::SerializeStruct for StructSerializer<'a> {
+impl<'a, 'b> ser::SerializeStruct for StructSerializer<'a, 'b> {
     type Ok = ();
     type Error = SerializerError;
 

--- a/meilidb-core/src/update/documents_addition.rs
+++ b/meilidb-core/src/update/documents_addition.rs
@@ -77,8 +77,8 @@ pub fn push_documents_addition<D: serde::Serialize>(
     Ok(last_update_id)
 }
 
-pub fn apply_documents_addition(
-    writer: &mut heed::RwTxn,
+pub fn apply_documents_addition<'a, 'b>(
+    writer: &'a mut heed::RwTxn<'b>,
     main_store: store::Main,
     documents_fields_store: store::DocumentsFields,
     documents_fields_counts_store: store::DocumentsFieldsCounts,

--- a/meilidb-core/src/update/mod.rs
+++ b/meilidb-core/src/update/mod.rs
@@ -149,8 +149,8 @@ pub fn next_update_id(
     Ok(new_update_id)
 }
 
-pub fn update_task(
-    writer: &mut heed::RwTxn,
+pub fn update_task<'a, 'b>(
+    writer: &'a mut heed::RwTxn<'b>,
     index: store::Index,
     update_id: u64,
     update: Update,

--- a/meilidb-core/src/update/mod.rs
+++ b/meilidb-core/src/update/mod.rs
@@ -152,12 +152,9 @@ pub fn next_update_id(
 pub fn update_task(
     writer: &mut heed::RwTxn,
     index: store::Index,
-) -> MResult<Option<ProcessedUpdateResult>> {
-    let (update_id, update) = match index.updates.pop_front(writer)? {
-        Some(value) => value,
-        None => return Ok(None),
-    };
-
+    update_id: u64,
+    update: Update,
+) -> MResult<ProcessedUpdateResult> {
     debug!("Processing update number {}", update_id);
 
     let (update_type, result, duration) = match update {
@@ -308,9 +305,5 @@ pub fn update_task(
         detailed_duration,
     };
 
-    index
-        .updates_results
-        .put_update_result(writer, update_id, &status)?;
-
-    Ok(Some(status))
+    Ok(status)
 }

--- a/meilidb-http/Cargo.toml
+++ b/meilidb-http/Cargo.toml
@@ -13,7 +13,7 @@ chrono = { version = "0.4.9", features = ["serde"] }
 crossbeam-channel = "0.3.9"
 envconfig = "0.5.1"
 envconfig_derive = "0.5.1"
-heed = "0.3.1"
+heed = "0.5.0"
 http = "0.1.19"
 indexmap = { version = "1.3.0", features = ["serde-1"] }
 jemallocator = "0.3.2"

--- a/meilidb-http/Cargo.toml
+++ b/meilidb-http/Cargo.toml
@@ -13,7 +13,7 @@ chrono = { version = "0.4.9", features = ["serde"] }
 crossbeam-channel = "0.3.9"
 envconfig = "0.5.1"
 envconfig_derive = "0.5.1"
-heed = "0.3.0"
+heed = "0.3.1"
 http = "0.1.19"
 indexmap = { version = "1.3.0", features = ["serde-1"] }
 jemallocator = "0.3.2"


### PR DESCRIPTION
Before this PR the update system wasn't consuming updates if those were failing.
Now we move all kind of updates to the updates results store even those failing. We store the error associated with the failing updates.