### PR TITLE
Fix an highlighting problem

### DIFF
--- a/meilidb-core/examples/from_file.rs
+++ b/meilidb-core/examples/from_file.rs
@@ -217,7 +217,11 @@ fn display_highlights(text: &str, ranges: &[usize]) -> io::Result<()> {
             _ => unreachable!(),
         };
         if highlighted {
-            stdout.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))?;
+            stdout.set_color(
+                ColorSpec::new()
+                    .set_fg(Some(Color::Yellow))
+                    .set_underline(true),
+            )?;
         }
         write!(&mut stdout, "{}", &text[start..end])?;
         stdout.reset()?;

--- a/meilidb-core/src/raw_indexer.rs
+++ b/meilidb-core/src/raw_indexer.rs
@@ -133,30 +133,20 @@ fn index_token(
                     .or_insert_with(Vec::new)
                     .push(docindex);
                 docs_words.entry(id).or_insert_with(Vec::new).push(word);
-            }
-            None => return false,
-        }
 
-        if !lower.contains(is_cjk) {
-            let unidecoded = deunicode_with_tofu(&lower, "");
-            if unidecoded != lower && !unidecoded.is_empty() {
-                let token = Token {
-                    word: &unidecoded,
-                    ..token
-                };
-
-                match token_to_docindex(id, attr, token) {
-                    Some(docindex) => {
-                        let word = Vec::from(token.word);
+                if !lower.contains(is_cjk) {
+                    let unidecoded = deunicode_with_tofu(&lower, "");
+                    if unidecoded != lower && !unidecoded.is_empty() {
+                        let word = Vec::from(unidecoded);
                         words_doc_indexes
                             .entry(word.clone())
                             .or_insert_with(Vec::new)
                             .push(docindex);
                         docs_words.entry(id).or_insert_with(Vec::new).push(word);
                     }
-                    None => return false,
                 }
             }
+            None => return false,
         }
     }
 


### PR DESCRIPTION
It happened when the query words were longer than the original area to highlight and was spotted thanks to unidecoded emojis.