### PR TITLE
Force the async-compression version

### DIFF
--- a/meilidb-http/Cargo.toml
+++ b/meilidb-http/Cargo.toml
@@ -33,7 +33,7 @@ walkdir = "2.2.9"
 [dependencies.async-compression]
 default-features = false
 features = ["stream", "gzip", "zlib", "brotli", "zstd"]
-version = "0.1.0-alpha.7"
+version = "=0.1.0-alpha.7"
 
 [dependencies.tide]
 git = "https://github.com/rustasync/tide"


### PR DESCRIPTION
I forced the `async-compression` crate to be `0.7.0-alpha.7`. I think that's one of the easiest and shortest fix I have ever done since long 😄 