### PR TITLE
Fix index creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ MeiliDB can serve multiple indexes, with different kinds of documents,
 therefore, it is required to create the index before sending documents to it.
 
 ```bash
-curl -i -X POST 'http://127.0.0.1:8080/indexes/movies'
+curl -i -X POST 'http://127.0.0.1:8080/indexes' --data '{ "name": "Movies", "uid": "movies" }'
 ```
 
 Now that the server knows about our brand new index, we can send it data.

--- a/meilidb-http/src/routes/index.rs
+++ b/meilidb-http/src/routes/index.rs
@@ -146,9 +146,14 @@ pub async fn create_index(mut ctx: Context<Data>) -> SResult<Response> {
         .await
         .map_err(ResponseError::bad_request)?;
 
-    let generated_uid = generate_uid();
-
     let db = &ctx.state().db;
+
+    let generated_uid = loop {
+        let uid = generate_uid();
+        if db.open_index(&uid).is_none() {
+            break uid;
+        }
+    };
 
     let created_index = match db.create_index(&generated_uid) {
         Ok(index) => index,

--- a/meilidb-http/src/routes/index.rs
+++ b/meilidb-http/src/routes/index.rs
@@ -123,6 +123,7 @@ pub async fn get_index(ctx: Context<Data>) -> SResult<Response> {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct IndexCreateRequest {
     name: String,
+    uid: Option<String>,
     schema: Option<SchemaBody>,
 }
 
@@ -148,14 +149,17 @@ pub async fn create_index(mut ctx: Context<Data>) -> SResult<Response> {
 
     let db = &ctx.state().db;
 
-    let generated_uid = loop {
-        let uid = generate_uid();
-        if db.open_index(&uid).is_none() {
-            break uid;
-        }
+    let uid = match body.uid {
+        Some(uid) => uid,
+        None => loop {
+            let uid = generate_uid();
+            if db.open_index(&uid).is_none() {
+                break uid;
+            }
+        },
     };
 
-    let created_index = match db.create_index(&generated_uid) {
+    let created_index = match db.create_index(&uid) {
         Ok(index) => index,
         Err(e) => return Err(ResponseError::create_index(e)),
     };
@@ -189,7 +193,7 @@ pub async fn create_index(mut ctx: Context<Data>) -> SResult<Response> {
 
     let response_body = IndexCreateResponse {
         name: body.name,
-        uid: generated_uid,
+        uid,
         schema: body.schema,
         update_id: response_update_id,
         created_at: Utc::now(),


### PR DESCRIPTION
With this changes we can now specify the uid of the index to simplify the usage of the database.